### PR TITLE
qbot: link Redmine project with Slack channel.

### DIFF
--- a/scripts/event-handler.coffee
+++ b/scripts/event-handler.coffee
@@ -100,6 +100,9 @@ module.exports = (robot) ->
     for idx,w of details.watchers
       notify_user w.login
 
+    if details.action == 'opened' or content.indexOf('to `New') >= 0
+      robot.emit 'channel-send', details.project_id, text, msg
+
   robot.on 'gerrit-notif', (details) ->
     # Build a pretty message for the related gerrit notif
     msg = {

--- a/scripts/redmine-handler.coffee
+++ b/scripts/redmine-handler.coffee
@@ -47,6 +47,7 @@ class RedmineNotifier extends notifier.NotifHandler
           tracker: issue.tracker.name
           priority: issue.priority.name
           project: issue.project.name
+          project_id: issue.project.identifier
           url: payload.url
           watchers: issue.watchers
           notes: if payload.journal? then payload.journal.notes else undefined


### PR DESCRIPTION
If an hook is setup for a Redmine project this patch allows to post on
Slack in the defined channel for every ticket created or set to New
in this project.